### PR TITLE
Not convert to OS-specific path when generate undohist file name

### DIFF
--- a/undohist.el
+++ b/undohist.el
@@ -68,7 +68,7 @@ To use undohist, you just call this function."
   (add-hook 'find-file-hook 'undohist-recover-safe))
 
 (defun make-undohist-file-name (file)
-  (setq file (convert-standard-filename (expand-file-name file)))
+  (setq file (expand-file-name file))
   (if (eq (aref file 1) ?:)
       (setq file (concat "/"
                          "drive_"


### PR DESCRIPTION
On windows, `convert-standard-name` will replace `/` with `\`, and then the following transformation (replace `/` with `!`) will work incorrectly, causing the generated file name invalid.
