### PR TITLE
autoload undohist-initialize

### DIFF
--- a/undohist.el
+++ b/undohist.el
@@ -201,6 +201,7 @@ recovering of undo history."
       (undohist-recover-1)
     (error (message "Can not recover undo history: %s" var))))
 
+;;;###autoload
 (defun undohist-initialize ()
   "Initialize undo history facilities.
 To use undohist, you just call this function."


### PR DESCRIPTION
I feel this would be useful. Especially for those of use who use things like use-package or leaf.

In my config this throws an error:

``` emacs-lisp
(leaf undohist
  :config
  (undohist-initialize))
```

If `undohist-initialize` is autoloaded, it works as expected.