### PR TITLE
Fix Byte Compile Error

### DIFF
--- a/undohist.el
+++ b/undohist.el
@@ -240,7 +240,7 @@ To use undohist, you just call this function."
                           (5 (kill-line))
                           (6 (kill-paragraph -1))
                           (7 (yank))
-                          (8 (kill-region (+ (point-min) (randppom (point-max))) (+ (point-min) (random (point-max))))))))
+                          (8 (kill-region (+ (point-min) (random (point-max))) (+ (point-min) (random (point-max))))))))
              (save-buffer)
              (undohist-save)
              (kill-buffer (current-buffer)))


### PR DESCRIPTION
Hi, this PR fixes the byte compile error:

```
In end of data:
undohist.el:243:59: Warning: the function ‘randppom’ is not known to be
    defined.
```
By renaming `randppom` to `random`, I'm guessing this is right looking at the function arguments and since `p` is close to `o` on the keyboard :smile: 
