### PR TITLE
Update README.md, reference undo-fu-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ Write the following code to your .emacs:
 
 Now you can record and recover undohist by typing C-x C-s (save-buffer) an 
 C-x C-f (find-file). And then type C-/ (undo).
+
+## Alternatives
+
+Note that this package is no longer actively maintained.
+
+- [undo-fu-session](https://melpa.org/#/undo-fu-session) is an updated
+  version of this package, with support for undo/redo and compression
+  among other improvements.
+
+- [undo-tree](https://elpa.gnu.org/packages/undo-tree.html) is an undo
+  system for Emacs, which includes support for restoring an undo-session
+  from saved files.


### PR DESCRIPTION
Reference undo-fu-session as `undohist` is no longer actively maintained.